### PR TITLE
Contributors: ensure that new features can be disabled if needed

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -50,6 +50,8 @@ Before a pull request is approved it must meet these criteria:
 - Pull request includes link to an osbs-docs PR for user documentation
   updates
 
+- New feature can be disabled from a configuration file
+
 Once it is approved by two developer team members someone from the
 team will merge it. To avoid creating merge commits the pull request
 will be rebased during the merge.


### PR DESCRIPTION
All features should have turn off switch in atomic-reactor config file

Signed-off-by: Martin Bašti <mbasti@redhat.com>