### PR TITLE
remove pulp from the documentation

### DIFF
--- a/docs/build_parameters.rst
+++ b/docs/build_parameters.rst
@@ -13,7 +13,7 @@ are reused. Environment parameters are shared by different build requests, while
 user parameters are unique to each build request.
 
 Environment parameters are used for configuring usage of external services such
-as Koji, Pulp, ODCS, SMTP, etc. They are also used for controlling some aspects
+as Koji, ODCS, SMTP, etc. They are also used for controlling some aspects
 of the container images built, for example, distribution scope, vendor,
 authoritative-registry, etc. These may change over time as the environment
 changes.
@@ -244,10 +244,10 @@ example, if **reactor_config** defines::
     - kojisecret
     - pulpsecret
 
-Secrets named **kojisecret** and **pulpsecret** must be available in orchestrator and
-worker clusters. They don't need to have the same value, just the same name. For
-instance, worker and orchestrator builds may use different authentication
-certificates.
+A secret named **kojisecret** must be available in orchestrator and
+worker clusters. The worker and orcestrator versions don't need to have the
+same value. For instance, worker and orchestrator builds may use different
+authentication certificates.
 
 Secrets needed for communication from orchestrator build to worker clusters are
 defined separately in **worker_token_secrets**. These are not passed along

--- a/docs/build_process.rst
+++ b/docs/build_process.rst
@@ -294,6 +294,9 @@ is deprecated (for all arrangements).
 For more details on how the build system is configured as of
 Arrangement 6, consult the :ref:`build_parameters` document.
 
+As of October 2019, Pulp is no longer supported in Arrangement 6 for either worker
+or orchestrator builds.
+
 
 Logging
 -------

--- a/docs/reference_docs.rst
+++ b/docs/reference_docs.rst
@@ -35,14 +35,6 @@ Python module and command line client for OpenShift Build Service.
 * `Configuration file <https://github.com/containerbuildsystem/osbs-client/blob/master/docs/configuration_file.md>`_
 
 
-dockpulp
---------
-
-ReST API Client to Pulp for manipulating docker images.
-
-* `Installation and Usage <https://github.com/release-engineering/dockpulp/blob/master/README.md>`_
-
-
 Ansible Playbook
 ----------------
 


### PR DESCRIPTION
part of osbs-5098

Remove all references to pulp and pulp related variables, except
for the pulp references in the historical overview of arrangements.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>