### PR TITLE
build_parameters: rm description of environment changes

### DIFF
--- a/docs/build_parameters.rst
+++ b/docs/build_parameters.rst
@@ -15,8 +15,7 @@ user parameters are unique to each build request.
 Environment parameters are used for configuring usage of external services such
 as Koji, ODCS, SMTP, etc. They are also used for controlling some aspects
 of the container images built, for example, distribution scope, vendor,
-authoritative-registry, etc. These may change over time as the environment
-changes.
+authoritative-registry, etc.
 
 User parameters contain the unique information for a user's build request: git
 repository, git branch, Koji target, etc. These should be reused for


### PR DESCRIPTION
It's technically true that these settings can change over time, but it's confusing to explicitly suggest that the settings change on a regular basis without going into more detail. Remove this sentence altogether.