### PR TITLE
users: align content_sets.yml anchor with "Content Sets" section

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -563,8 +563,6 @@ The steps above apply to a single branch in your dist-git repo.
 It must be repeated for each branch you wish to disable the feature.
 
 
-.. _content_sets.yml:
-
 image_build_method
 ~~~~~~~~~~~~~~~~~~
 
@@ -584,6 +582,8 @@ In order to use the **imagebuilder** plugin, the imagebuilder_ binary must be
 available and in the PATH for the builder image, or an error will result.
 
 .. _imagebuilder: https://github.com/openshift/imagebuilder/
+
+.. _content_sets.yml:
 
 Content Sets
 ------------


### PR DESCRIPTION
Prior to this change, the content_sets anchor was pointing at the image_build_method section. This caused Sphinx to generate links like "See image_build_method" instead of "See content_sets.yml".