### PR TITLE
remove references to pdc support

### DIFF
--- a/docs/.aspell.en.pws
+++ b/docs/.aspell.en.pws
@@ -89,7 +89,6 @@ Kubernetes
 BType
 containerbuild
 runtimes
-pdc
 mavenfile
 abc
 pulpsecret

--- a/docs/build_parameters.rst
+++ b/docs/build_parameters.rst
@@ -112,9 +112,6 @@ Example of **REACTOR_CONFIG**::
         send_to_submitter: True
         send_to_pkg_owner: True
 
-    pdc:
-        api_url: https://pdc.example.com/rest_api/v1
-
     arrangement_version: 6
 
     artifacts_allowed_domains:


### PR DESCRIPTION
pdc support was deprecated in September 2018, so remove the last remnants
of it from the documentation.

Signed-off-by: Mark Langsdorf <mlangsdo@redhat.com>