### PR TITLE
Fix links to OKD docs

### DIFF
--- a/docs/build_process.rst
+++ b/docs/build_process.rst
@@ -37,7 +37,8 @@ The orchestrator build makes use of :ref:`config.yaml` to discover
 which worker clusters to direct builds to and whether/which `node
 selector`_ is required for each.
 
-.. _`node selector`: https://docs.okd.io/latest/admin_guide/managing_projects.html#developer-specified-node-selectors
+.. _`node selector`: https://docs.okd.io/3.11/admin_guide/managing_projects.html#developer-specified-node-selectors
+
 
 The separation of tasks between the orchestrator build and the worker
 build is called the "arrangement".

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ OSBS is a collection of tools, workflows and integration points that build and r
 
 OSBS hooks into Koji_ with the help of the `koji-containerbuild plugin
 <https://github.com/containerbuildsystem/koji-containerbuild>`_, and
-uses `OpenShift builds <https://docs.okd.io/latest/dev_guide/builds/index.html>`_ as Content Generators to produce layered images.
+uses `OpenShift builds <https://docs.okd.io/3.11/dev_guide/builds/index.html>`_ as Content Generators to produce layered images.
 
 .. _Koji: https://pagure.io/koji
 

--- a/docs/users.rst
+++ b/docs/users.rst
@@ -278,7 +278,7 @@ file in the git repository named ``container.yaml``. This file need
 not be present, but if it is it must adhere to the `container.yaml
 schema`_.
 
-.. _`container.yaml schema`: https://github.com/containerbuildsystem/atomic-reactor/blob/master/atomic_reactor/schemas/container.json
+.. _`container.yaml schema`: https://github.com/containerbuildsystem/osbs-client/blob/master/osbs/schemas/container.json
 
 An example::
 


### PR DESCRIPTION
Documentation pinned to okd 3.11 as latest version changes

Signed-off-by: Martin Bašti <mbasti@redhat.com>