### PR TITLE
users: describe koji_parent_build for multi-stage builds

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -895,12 +895,12 @@ build.
 Override Parent Image
 ----------------------
 
-The parent image used for building a layered image is determined by the ``FROM``
-instruction in the Dockerfile by default. Users can override this behavior
-by specifying a koji parent build via the ``koji_parent_build`` API parameter.
-When given, the image reference in the provided koji parent build will be used as
-the value of the FROM instruction. The same source registry restrictions
-apply.
+OSBS uses the ``FROM`` instruction in the Dockerfile to find a parent image
+for a layered image build. Users can override this behavior by specifying a
+koji parent build via the ``koji_parent_build`` API parameter. When a user
+specifies a ``koji_parent_build`` parameter, OSBS will look up the image
+reference for that koji build and override the ``FROM`` instruction with that
+image instead. The same source registry restrictions apply.
 
 Additionally, the koji parent build must use the same container image repository
 as the value of the FROM instruction in Dockerfile. For instance, if the

--- a/docs/users.rst
+++ b/docs/users.rst
@@ -900,7 +900,9 @@ for a layered image build. Users can override this behavior by specifying a
 koji parent build via the ``koji_parent_build`` API parameter. When a user
 specifies a ``koji_parent_build`` parameter, OSBS will look up the image
 reference for that koji build and override the ``FROM`` instruction with that
-image instead. The same source registry restrictions apply.
+image instead. The same source registry restrictions apply. For multi-stage
+builds, the ``koji_parent_build`` parameter will only override the final
+``FROM`` instruction.
 
 Additionally, the koji parent build must use the same container image repository
 as the value of the FROM instruction in Dockerfile. For instance, if the


### PR DESCRIPTION
The first commit rewrites the first paragraph in the "Override Parent Image" section to use the active voice so that users can understand it more easily.

The second commit clarifies that OSBS will only override the final "FROM" instruction for a multi-stage build.

Fixes: #118