### PR TITLE
Document relation of pull_registries to operators

### DIFF
--- a/docs/admins.rst
+++ b/docs/admins.rst
@@ -517,6 +517,9 @@ allowed_registries
   found whose registry is not in ``allowed_registries``, build will fail. This
   key is required.
 
+  Should be a subset of ``source_registry + pull_registries`` (see
+  `config.json`_).
+
 repo_replacements
   Each registry may optionally have a "package mapping" - a YAML file that
   contains a mapping of [package name => list of repos] (see


### PR DESCRIPTION
* CLOUDLD-397

Mention that allowed_registries for operator digest pinning should be
a subset of source_registry + pull_registries.

Documentation for users has no concept of supported/unsupported
registries, it should be fine to keep it that way.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>