### PR TITLE
add documentation for metadata updates for fetch-artifacts-koji metadata

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -1019,10 +1019,13 @@ and verified.
 Koji Build Metadata Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In the future, a reference of each artifact fetched by OSBS will be
-added to the koji build metadata once imported via content generator API.
-The list of components for the container image in output list will
-include the fetched artifacts in addition to the installed RPMs.
+A reference of each artifact fetched by OSBS is added to the koji build metadata
+once imported via content generator API. The list of components for the
+container image in output list includes the fetched artifacts in addition to the
+installed RPMs.
+
+Metadata for artifacts fetched using fetch-artifacts-koji are added as kojifile type
+components under image output alongside the rpm type components.
 
 .. _image-tags:
 


### PR DESCRIPTION
All artifacts fetched via fetch-artifacts-koji will now be included
in brew image metadata

MMENG-1275

Signed-off-by: Harsh Modi <hmodi@redhat.com>