### PR TITLE
Remove traces of Pulp image registry

### DIFF
--- a/docs/.aspell.en.pws
+++ b/docs/.aspell.en.pws
@@ -35,7 +35,6 @@ fedpkg
 SerialLatestOnly
 graphviz
 ImageChangeTriggers
-dockpulp
 distro
 LoggerAdapter
 userId
@@ -91,7 +90,6 @@ containerbuild
 runtimes
 mavenfile
 abc
-pulpsecret
 ksurl
 uri
 imagestream

--- a/docs/build_parameters.rst
+++ b/docs/build_parameters.rst
@@ -85,11 +85,6 @@ Example of **REACTOR_CONFIG**::
             ssl_certs_dir: /var/run/secrets/atomic-reactor/kojisecret
         use_fast_upload: false
 
-    pulp:
-        name: my-pulp
-        auth:
-            ssl_certs_dir: /var/run/secrets/atomic-reactor/pulpsecret
-
     odcs:
         api_url: https://odcs.example.com/api/1
         auth:
@@ -161,7 +156,6 @@ Example of **REACTOR_CONFIG**::
 
     required_secrets:
     - kojisecret
-    - pulpsecret
     - odcssecret
     - v2-registry-dockercfg
     - client-config-secret
@@ -255,7 +249,6 @@ example, if **reactor_config** defines::
 
     required_secrets:
     - kojisecret
-    - pulpsecret
 
 A secret named **kojisecret** must be available in orchestrator and
 worker clusters. The worker and orchestrator versions don't need to have the

--- a/docs/users.rst
+++ b/docs/users.rst
@@ -1157,7 +1157,7 @@ Image tags
 ----------
 
 OSBS's atomic-reactor pushes the new container image to the container
-registry (or Pulp, if Pulp integration is enabled) and updates various tag
+registry and updates various tag
 references in the registry. In addition, when multi-platform builds are
 enabled, atomic-reactor groups each set of images into a manifest list
 and tags that manifest list.


### PR DESCRIPTION
Pulp registry is unsupported for long time already

Signed-off-by: Martin Basti <mbasti@redhat.com>