### PR TITLE
Fix repo=url parameter typo

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -1572,7 +1572,7 @@ to discover the kickstart configuration used for the built image.
 
 To execute base image build, run::
 
-  fedpkg container-build --target=<target> --repo=url=<repo-url>
+  fedpkg container-build --target=<target> --repo-url=<repo-url>
 
 The --repo-url parameter specifies the URL to a repofile. The first section
 of this is inspected and the 'baseurl' is examined to discover the compose URL.


### PR DESCRIPTION
In [Base image builds](https://osbs.readthedocs.io/en/latest/users.html#odcs-compose), there is a parameter typo. This PR replaces `repo=url` with `repo-url` in the code example.