### PR TITLE
Document valid pattern for floating tags

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -1202,7 +1202,8 @@ tagging the resulting image in the registry:
   over time. In other words, every time you build a new container image,
   OSBS updates these floating tags. Examples: ``latest``, or ``{version}``
 
-  The floating tags must match the pattern `^[\w.]{0,127}$`. 
+  The floating tags must match the pattern `^[\w.]{0,127}$`. For example, 
+  `3scale2.12.dev` is a valid tag, but `3scale2.12-dev` isn't.
   
   Floating tags are configurable. If you set ``tags`` in container.yaml, OSBS
   applies those tags to your newly-built image as floating tags.

--- a/docs/users.rst
+++ b/docs/users.rst
@@ -1202,6 +1202,8 @@ tagging the resulting image in the registry:
   over time. In other words, every time you build a new container image,
   OSBS updates these floating tags. Examples: ``latest``, or ``{version}``
 
+  The floating tags must match the pattern `^[\w.]{0,127}$`. 
+  
   Floating tags are configurable. If you set ``tags`` in container.yaml, OSBS
   applies those tags to your newly-built image as floating tags.
 


### PR DESCRIPTION
I came across this issue when trying to use a tag that contains a `-` in an OpenShift Build Service (OSBS) build for 3scale API Management.