### PR TITLE
Remove reference to undefined label group_manifests

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -1128,10 +1128,8 @@ tagging the resulting image in the registry:
     and will no longer be supported in a future version. Please consider using
     ``tags`` in container.yaml instead)
 
-These tags are applied to the manifest list or, if multi-platform
-image builds are not enabled (see :ref:`group_manifests
-<group-manifests>`), to the sole image manifest resulting from the
-build.
+These tags are applied to the manifest list or, if multi-platform image builds
+are not enabled, to the sole image manifest resulting from the build.
 
 Override Parent Image
 ----------------------


### PR DESCRIPTION
Label group_manifests was defined in the Orchestrator section, which has
been removed during development of OSBS 2. This change is helpful to
make the `make html' succeed completely in local to generate complete
static site content.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>