### PR TITLE
Document deprecated "go" settings

### DIFF
--- a/docs/users.rst
+++ b/docs/users.rst
@@ -390,7 +390,7 @@ not
 go
 ~~
 
-.. warning:: Using this key is deprecated in favor of using Cachito integration
+.. warning:: Using this key is deprecated in favor of using Cachito integration. To switch to Cachito, set the ``remote_sources`` key instead. OSBS does not permit users to specify a ``go`` key with a ``remote_sources`` key.
 
 Keys in this map relate to source code in the Go language which the
 user intends to be built into the container image. They are


### PR DESCRIPTION
CLOUDBLD-8399

Signed-off-by: Sumin Cho <sucho@redhat.com>

Reference to Issue #163:

> We should update the documentation to steer users away from using the go key in container.yaml. This is the old deprecated way of performing container-first builds in OSBS. Cachito is the replacement. To switch to Cachito, set the remote_source key instead. OSBS does not permit users to specify a go key with a remote_source key.

I have added this information to the warning tag under "go" section.