### PR TITLE
undocument cachito single remote source

### DIFF
--- a/docs/admins.rst
+++ b/docs/admins.rst
@@ -494,6 +494,8 @@ This section describes how to configure OSBS to use cachito as described above.
 :ref:`cachito-usage` describes how to get OSBS to use cachito in
 a specific container build, as an OSBS user.
 
+.. _configure-cachito-instance:
+
 Configuring your cachito instance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
CLOUDBLD-6771

Since using multiple remote sources in cachito is
preferred and because we intend to deprecate the
single remote source option in the future, multiple
remote sources should be presented as the only option

Signed-off-by: Taylor Madore <tmadore@redhat.com>